### PR TITLE
fix: correct dependency version format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,18 +6,18 @@ build-backend = "hatchling.build"
 name = "ageval"
 version = "0.1.0"
 dependencies = [
-  "python-dotenv=1.1.1",
-  "black=25.1.0",
-  "jupyter=1.1.1",
-  "pandarallel=1.6.5",
-  "hydra-core=1.3.2",
-  "hydra-joblib-launcher=1.2.0",
-  "loguru=0.7.3",
-  "wandb=0.21.0",
-  "absl-py=2.3.1",
-  "scienceplots=2.1.1",
-  "datasets=3.6.0",
-  "alpaca-eval=0.6.6",
+  "python-dotenv==1.1.1",
+  "black==25.1.0",
+  "jupyter==1.1.1",
+  "pandarallel==1.6.5",
+  "hydra-core==1.3.2",
+  "hydra-joblib-launcher==1.2.0",
+  "loguru==0.7.3",
+  "wandb==0.21.0",
+  "absl-py==2.3.1",
+  "scienceplots==2.1.1",
+  "datasets==3.6.0",
+  "alpaca-eval==0.6.6",
 ]
 requires-python = ">=3.10"
 authors = [


### PR DESCRIPTION
- Replace single equals (=) with double equals (==) for version pinning
- This was causing pip install failures with metadata generation errors
- Affects all package dependencies in the main dependencies list
- No functional changes, only syntax correction for proper PEP 508 format

Fixes #<issue-number> if there was one